### PR TITLE
Removed JDK9 dependencies

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -58,13 +58,6 @@
             <version>1.1.4</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -58,13 +58,6 @@
             <version>1.1.4</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Addressing https://github.com/OpenLiberty/guides-common/issues/459

- Tested end-to-end with JDK 11.0.7
- Tested end-to-end with JDK 1.8.0_252