### PR TITLE
Temporarily use Open Liberty 22.0.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: bash ./tools/pr-checker/checker.sh ${{ github.repository }} ${{ github.event.pull_request.number }} | tee checker.log 
       - id: Lint-Code-Base
         if: always()
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.17.0
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -79,6 +79,9 @@
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>3.5.1</version>
+                <configuration>
+                    <liberty.runtime.version>22.0.0.2</liberty.runtime.version>
+                </configuration>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -79,6 +79,9 @@
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>3.5.1</version>
+                <configuration>
+                    <liberty.runtime.version>22.0.0.2</liberty.runtime.version>
+                </configuration>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>


### PR DESCRIPTION
 Because openapi/ui not work well in OL 22.0.0.3, temporarily use Open Liberty 22.0.0.2.