### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <liberty.var.app.context.root>Spacecraft</liberty.var.app.context.root>
     </properties>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -37,13 +37,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -72,22 +72,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                         <war.name>${liberty.var.app.context.root}</war.name>
                     </systemPropertyVariables>
                 </configuration>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -10,11 +10,11 @@
         <feature>mpOpenAPI-3.1</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="Spacecraft"/>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
         id="defaultHttpEndpoint" host="*" />
 
    <webApplication location="guide-bean-validation.war" contextRoot="${app.context.root}"/>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <liberty.var.app.context.root>Spacecraft</liberty.var.app.context.root>
     </properties>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -37,13 +37,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -72,22 +72,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                         <war.name>${liberty.var.app.context.root}</war.name>
                     </systemPropertyVariables>
                 </configuration>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -7,11 +7,11 @@
         <feature>mpOpenAPI-3.1</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="Spacecraft"/>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
         id="defaultHttpEndpoint" host="*" />
 
    <webApplication location="guide-bean-validation.war" contextRoot="${app.context.root}"/>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

